### PR TITLE
Remove the aggressive-loop-optimizations warning

### DIFF
--- a/inc/set.h
+++ b/inc/set.h
@@ -209,7 +209,7 @@ public:
 		int lim = ((n | 63) + 1) / 64;
 
 		// bitwise OR the other bits into this set
-		for (int i=0; i<lim; i++) data.bits[i] |= other.data.bits[i];
+		for (volatile int i=0; i<lim; i++) data.bits[i] |= other.data.bits[i];
 	}
 
 	// expand the entire set into the array v, returning the cardinality


### PR DESCRIPTION
General build instructions
```
Building single-core ChampSim...

rm -f -r obj
Generating dependencies for src/ooo_cpu.cc...
Compiling src/ooo_cpu.cc...
Generating dependencies for src/cache.cc...
Compiling src/cache.cc...
In file included from inc/instruction.h:13:0,
                 from inc/block.h:5,
                 from inc/memory_class.h:5,
                 from inc/cache.h:4,
                 from src/cache.cc:1:
inc/set.h: In member function ‘void CACHE::handle_read()’:
inc/set.h:212:63: warning: iteration 4u invokes undefined behavior [-Waggressive-loop-optimizations]
   for (int i=0; i<lim; i++) data.bits[i] |= other.data.bits[i];
                                                               ^
inc/set.h:212:18: note: containing loop
   for (int i=0; i<lim; i++) data.bits[i] |= other.data.bits[i];

```
The compiler optimizes this part for the condition where `lim` > `other.data.bits[MAXLIMIT]`
This is a fix for the redundant optimization. 